### PR TITLE
Bump stressor image version

### DIFF
--- a/deploy/stressor/values.yaml
+++ b/deploy/stressor/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
-  repository: eu.gcr.io/kyma-project/develop/service-catalog-tester
-  tag: 0.1.7
+  repository: eu.gcr.io/kyma-project/incubator/develop/service-catalog-tester
+  tag: 3c2be629
   pullPolicy: IfNotPresent
 
 app:


### PR DESCRIPTION
Related issues:
* [SC-tester needs update to work with current version of Kyma](https://github.com/kyma-incubator/service-catalog-tester/issues/7)